### PR TITLE
Allow request body parameters (POST) for custom data

### DIFF
--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -79,8 +79,13 @@ class DataTables implements DataTablesInterface
         $params->length     = $request->get('length');
         $params->search     = $request->get('search');
         $params->order      = $request->get('order');
-        $params->columns    = $request->get('columns');
-        $params->customData = array_diff_key($request->query->all(), array_flip($keyParams));
+        $params->columns = $request->get('columns');
+        if ($request->isMethod('POST')) {
+            $allParams = $request->request->all();
+        } else {
+            $allParams = $request->query->all();
+        }
+        $params->customData = array_diff_key($allParams, array_flip($keyParams));
 
         // Validate sent parameters.
         $violations = $this->validator->validate($params);


### PR DESCRIPTION
When I use DataTables Ajax with type POST, I cannot get customData since customData is only available through query parameters. Therefore I need to check whether the request is POST or GET. If it is POST request then all parameters are in `$request->request->all() `instead of `$request->query->all()`.